### PR TITLE
Move Mongojack Micronaut integration to own module

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,12 +28,10 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api")
     compileOnly("io.micronaut.reactor:micronaut-reactor")
 
-    implementation("org.mongojack:mongojack:4.3.0")
-    implementation("io.micronaut.mongodb:micronaut-mongo-sync")
-
     implementation("io.swagger.core.v3:swagger-annotations")
 
     implementation(project(":dto_common"))
+    implementation(project(":micronaut-mongojack"))
 
     testImplementation("org.testcontainers:mongodb:1.16.2")
     testCompileOnly("io.micronaut.reactor:micronaut-reactor")

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,1 +1,0 @@
-micronautVersion=3.2.0

--- a/backend/src/main/java/club/devcord/devmarkt/Application.java
+++ b/backend/src/main/java/club/devcord/devmarkt/Application.java
@@ -2,15 +2,11 @@ package club.devcord.devmarkt;
 
 import com.mongodb.client.MongoClient;
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.runtime.Micronaut;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-@Introspected(packages = {
-    "club.devcord.devmarkt.dto.template"
-}, includedAnnotations = club.devcord.devmarkt.dto.Introspected.class)
 @OpenAPIDefinition(
     info = @Info(
         title = "Devmarkt-Backend",

--- a/backend/src/main/java/club/devcord/devmarkt/mongodb/service/template/TemplateDAO.java
+++ b/backend/src/main/java/club/devcord/devmarkt/mongodb/service/template/TemplateDAO.java
@@ -17,7 +17,7 @@
 package club.devcord.devmarkt.mongodb.service.template;
 
 import club.devcord.devmarkt.dto.template.Template;
-import club.devcord.devmarkt.mongodb.Collection;
+import club.devcord.devmarkt.micronaut_mongojack.Collection;
 import club.devcord.devmarkt.mongodb.Collections;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,3 +6,4 @@ micronaut:
     host: ${devmarkt.server.host:`localhost`}
 mongodb:
   uri: mongodb://${devmarkt.mongodb.user:mongodb}:${devmarkt.mongodb.password:passy}@${devmarkt.mongodb.host:localhost}:${devmarkt.mongodb.port:27017}
+  database: ${devmarkt.mongodb.database}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -4,6 +4,7 @@ micronaut:
 
 mongodb:
   uri: mongodb://localhost:${test.mongo-port}
+  database: test
 
 test:
   mongo-port: ${random.port}

--- a/dto_common/build.gradle.kts
+++ b/dto_common/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    id("io.micronaut.library") version "3.0.1"
 }
 
 group = "club.devcord.devmarkt"
@@ -16,17 +17,10 @@ java {
 }
 
 dependencies {
+    annotationProcessor("io.micronaut:micronaut-inject-java")
+
     compileOnly("org.mongojack:mongojack:4.3.0")
-
-    implementation("io.swagger.core.v3:swagger-annotations:2.1.11")
-
+    compileOnly("io.swagger.core.v3:swagger-annotations:2.1.11")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-}
-
-tasks.getByName<Test>("test") {
-    useJUnitPlatform()
-    this.testLogging {
-        this.showStandardStreams = true
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 Contributors to the Devmarkt-Backend project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+micronautVersion=3.2.0

--- a/micronaut-mongojack/build.gradle.kts
+++ b/micronaut-mongojack/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("io.micronaut.library") version "3.0.1"
+}
+
+version = "0.1"
+group = "club.devcord.devmarkt"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-inject-java")
+    api("org.mongojack:mongojack:4.3.0")
+    api("io.micronaut.mongodb:micronaut-mongo-sync")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}

--- a/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/Collection.java
+++ b/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/Collection.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package club.devcord.devmarkt.mongodb;
+package club.devcord.devmarkt.micronaut_mongojack;
 
-public class NoCollectionTypeProvided extends RuntimeException {
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
-  public NoCollectionTypeProvided() {
-    super("No collection type provided");
-  }
-
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Collection {
+  Class<?> value();
 }

--- a/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/MongoCollectionFactory.java
+++ b/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/MongoCollectionFactory.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package club.devcord.devmarkt.micronaut_mongojack;
 
-package club.devcord.devmarkt.mongodb;
-
-import club.devcord.devmarkt.dto.Introspected;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -29,14 +27,13 @@ import org.bson.UuidRepresentation;
 import org.mongojack.JacksonMongoCollection;
 
 @Factory
-@Requires(property = "devmarkt.mongodb.database", classes = {MongoClient.class, ObjectMapper.class})
-@Introspected
+@Requires(property = "mongodb.database", beans = {MongoClient.class, ObjectMapper.class})
 @SuppressWarnings("unchecked")
 public class MongoCollectionFactory {
 
   @Prototype
   public <T> MongoCollection<T> mongoCollection(MongoClient client,
-      @Value("${devmarkt.mongodb.database}") String database, ObjectMapper mapper,
+      @Value("${mongodb.database}") String database, ObjectMapper mapper,
       InjectionPoint<?> injectionPoint) {
 
     Class<T> clazz = injectionPoint

--- a/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/NoCollectionTypeProvided.java
+++ b/micronaut-mongojack/src/main/java/club/devcord/devmarkt/micronaut_mongojack/NoCollectionTypeProvided.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package club.devcord.devmarkt.mongodb;
+package club.devcord.devmarkt.micronaut_mongojack;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+public class NoCollectionTypeProvided extends RuntimeException {
 
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Collection {
-  Class<?> value();
+  public NoCollectionTypeProvided() {
+    super("No collection type provided");
+  }
+
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "devmarkt-backend"
 include("backend")
 include("dto_common")
+include("micronaut-mongojack")


### PR DESCRIPTION
Moves Mongojack Micronaut integration to own module to allow use in other modules (future plans) and add compile time bean introspection for modules beside "backend"