### PR TITLE
Remove obsolete linting rule

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -90,12 +90,6 @@ if (modifiedFiles.some(file => file.includes(".idea"))) {
   fn("This PR modifies the IntelliJ IDEA setting files");
 }
 
-if (modifiedFiles.some(file => file.includes("src/main/resources/db/seeder"))
-    !== modifiedFiles.some(file => file.includes(
-        "src/test/java/club/devcord/devmarkt/Seed.java"))) {
-  warn("The `Seed` class needs to be checked if it is up to date");
-}
-
 if (notAddedFiles.some(
         file => file.includes("src/main/resources/db/migrations"))
     && danger.github?.pr?.base?.ref === 'main'


### PR DESCRIPTION
Since the unit tests are all gone and replaced by qa tests, there is not Seed class anymore which needs to be up to date with the seeder