### PR TITLE
Remove testcontainers dependency

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
     runtimeOnly("io.micronaut.sql:micronaut-jdbc-hikari")
 
     implementation("ch.qos.logback:logback-classic")
-
-    testImplementation("org.testcontainers:testcontainers:1.17.1")
-    testImplementation("org.testcontainers:postgresql:1.17.1")
 }
 
 


### PR DESCRIPTION
Testcontainers is not used anymore as we completely use the qa system tests