### PR TITLE
Bump io.micronaut.application from 3.7.10 to 4.0.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,10 +47,12 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Build with Gradle
+        run: ./gradlew --build-cache build -x test
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     // When.MAYBE warning fix
     annotationProcessor("com.google.code.findbugs:jsr305:3.0.2")
     implementation("ch.qos.logback:logback-classic:1.4.11")
+    implementation("org.slf4j:slf4j-api:2.0.7")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("io.micronaut.security:micronaut-security-jwt")
     implementation("io.micronaut.reactor:micronaut-reactor")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.micronaut.application") version "3.7.10"
+    id("io.micronaut.application") version "4.0.1"
 }
 
 version = "2.0"
@@ -23,6 +23,7 @@ dependencies {
     annotationProcessor("io.micronaut.security:micronaut-security-annotations")
     annotationProcessor("io.micronaut.data:micronaut-data-processor")
     annotationProcessor("io.micronaut:micronaut-inject-java")
+    annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
     // When.MAYBE warning fix
     annotationProcessor("com.google.code.findbugs:jsr305:3.0.2")
     implementation("ch.qos.logback:logback-classic:1.4.11")
@@ -35,9 +36,10 @@ dependencies {
     implementation("io.micronaut.graphql:micronaut-graphql")
     implementation("com.graphql-java-kickstart:graphql-java-tools:13.0.3")
     implementation("com.graphql-java:graphql-java-extended-validation:20.0-validator-6.2.0.Final")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("io.micronaut.sql:micronaut-jdbc-hikari")
+    runtimeOnly("org.yaml:snakeyaml")
 
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -33,9 +33,8 @@ dependencies {
     implementation("io.micronaut.reactor:micronaut-reactor")
     implementation("io.micronaut:micronaut-runtime")
     implementation("io.micronaut.data:micronaut-data-jdbc")
-    // https://github.com/flyway/flyway/issues/3651
-    // 6.0.0-M2 uses 9.16.1 which is before bug introduced in flyway
     implementation("io.micronaut.flyway:micronaut-flyway")
+    // https://github.com/flyway/flyway/issues/3651
     implementation("org.flywaydb:flyway-core") {
         version {
             strictly("9.16.1")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -32,7 +32,9 @@ dependencies {
     implementation("io.micronaut.reactor:micronaut-reactor")
     implementation("io.micronaut:micronaut-runtime")
     implementation("io.micronaut.data:micronaut-data-jdbc")
-    implementation("io.micronaut.flyway:micronaut-flyway")
+    // https://github.com/flyway/flyway/issues/3651
+    // 6.0.0-M2 uses 9.16.1 which is before bug introduced in flyway
+    implementation("io.micronaut.flyway:micronaut-flyway:6.0.0-M2")
     implementation("io.micronaut.graphql:micronaut-graphql")
     implementation("com.graphql-java-kickstart:graphql-java-tools:13.0.3")
     implementation("com.graphql-java:graphql-java-extended-validation:20.0")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.micronaut.application") version "4.0.1"
+    id("io.micronaut.application") version "4.0.2"
 }
 
 version = "2.0"

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("io.micronaut.flyway:micronaut-flyway")
     implementation("io.micronaut.graphql:micronaut-graphql")
     implementation("com.graphql-java-kickstart:graphql-java-tools:13.0.3")
-    implementation("com.graphql-java:graphql-java-extended-validation:20.0-validator-6.2.0.Final")
+    implementation("com.graphql-java:graphql-java-extended-validation:20.0")
     implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("io.micronaut.sql:micronaut-jdbc-hikari")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,7 +35,12 @@ dependencies {
     implementation("io.micronaut.data:micronaut-data-jdbc")
     // https://github.com/flyway/flyway/issues/3651
     // 6.0.0-M2 uses 9.16.1 which is before bug introduced in flyway
-    implementation("io.micronaut.flyway:micronaut-flyway:6.0.0-M2")
+    implementation("io.micronaut.flyway:micronaut-flyway")
+    implementation("org.flywaydb:flyway-core") {
+        version {
+            strictly("9.16.1")
+        }
+    }
     implementation("io.micronaut.graphql:micronaut-graphql")
     implementation("com.graphql-java-kickstart:graphql-java-tools:13.0.3")
     implementation("com.graphql-java:graphql-java-extended-validation:20.0")

--- a/backend/src/main/java/club/devcord/devmarkt/auth/UserIdValidator.java
+++ b/backend/src/main/java/club/devcord/devmarkt/auth/UserIdValidator.java
@@ -20,6 +20,7 @@ import club.devcord.devmarkt.entities.auth.UserId;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.token.jwt.validator.JwtTokenValidator;
 import jakarta.inject.Singleton;
+import java.security.Principal;
 import java.util.regex.Pattern;
 import reactor.core.publisher.Mono;
 
@@ -35,7 +36,10 @@ public class UserIdValidator {
   }
 
   public UserId validateUserIdFromToken(String token) {
-    return Mono.from(validator.validateToken(token, null))
+
+    Mono<Authentication> authenticationMono = Mono.<Authentication>from(validator.validateToken(token, null));
+
+    return authenticationMono
         .map(Authentication::getName)
         .mapNotNull(this::validateUserId)
         .block();

--- a/backend/src/main/java/club/devcord/devmarkt/entities/application/Application.java
+++ b/backend/src/main/java/club/devcord/devmarkt/entities/application/Application.java
@@ -26,7 +26,7 @@ import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.annotation.Relation;
 import io.micronaut.data.annotation.Relation.Cascade;
 import io.micronaut.data.annotation.Relation.Kind;
-import io.micronaut.data.jdbc.annotation.ColumnTransformer;
+import io.micronaut.data.annotation.sql.ColumnTransformer;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/backend/src/main/java/club/devcord/devmarkt/entities/auth/User.java
+++ b/backend/src/main/java/club/devcord/devmarkt/entities/auth/User.java
@@ -24,7 +24,7 @@ import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.annotation.MappedProperty;
 import io.micronaut.data.annotation.Relation;
 import io.micronaut.data.annotation.Relation.Kind;
-import io.micronaut.data.jdbc.annotation.ColumnTransformer;
+import io.micronaut.data.annotation.sql.ColumnTransformer;
 
 @GraphQLType("User")
 @MappedEntity("users")

--- a/backend/src/main/java/club/devcord/devmarkt/qa/QaDatabaseSeeding.java
+++ b/backend/src/main/java/club/devcord/devmarkt/qa/QaDatabaseSeeding.java
@@ -35,7 +35,7 @@ import io.micronaut.transaction.exceptions.TransactionSystemException;
 import jakarta.inject.Singleton;
 import java.sql.PreparedStatement;
 import java.util.List;
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import org.flywaydb.core.Flyway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/backend/src/main/java/club/devcord/devmarkt/repositories/TemplateRepo.java
+++ b/backend/src/main/java/club/devcord/devmarkt/repositories/TemplateRepo.java
@@ -23,12 +23,13 @@ import io.micronaut.data.annotation.Join;
 import io.micronaut.data.annotation.Join.Type;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
 import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
-@JdbcRepository
+@JdbcRepository(dialect = Dialect.POSTGRES)
 public interface TemplateRepo extends CrudRepository<Template, Integer> {
 
   boolean existsByName(String name);
@@ -36,7 +37,7 @@ public interface TemplateRepo extends CrudRepository<Template, Integer> {
   @Override
   @IgnoreWhere
   @Join(value = "questions", type = Type.LEFT_FETCH)
-  Optional<Template> findById(@javax.validation.constraints.NotNull Integer integer);
+  Optional<Template> findById(@jakarta.validation.constraints.NotNull Integer integer);
 
   @Executable
   @Join(value = "questions", type = Type.LEFT_FETCH)

--- a/backend/src/main/java/club/devcord/devmarkt/ws/CustomGraphQLWsController.java
+++ b/backend/src/main/java/club/devcord/devmarkt/ws/CustomGraphQLWsController.java
@@ -18,10 +18,10 @@ package club.devcord.devmarkt.ws;
 
 import io.micronaut.configuration.graphql.GraphQLConfiguration;
 import io.micronaut.configuration.graphql.GraphQLJsonSerializer;
-import io.micronaut.configuration.graphql.ws.GraphQLWsConfiguration;
-import io.micronaut.configuration.graphql.ws.GraphQLWsController;
-import io.micronaut.configuration.graphql.ws.GraphQLWsRequest.ClientType;
-import io.micronaut.configuration.graphql.ws.GraphQLWsResponse;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsConfiguration;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsController;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsRequest.ClientType;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.websocket.CloseReason;
 import io.micronaut.websocket.WebSocketSession;
@@ -33,15 +33,15 @@ import io.micronaut.websocket.annotation.ServerWebSocket;
 import java.util.Map;
 import org.reactivestreams.Publisher;
 
-@ServerWebSocket(value = "${" + GraphQLConfiguration.PREFIX + "." + GraphQLWsConfiguration.PATH + ":"
-    + GraphQLWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-ws")
+@ServerWebSocket(value = "${" + GraphQLConfiguration.PREFIX + "." + GraphQLApolloWsConfiguration.PATH_CONFIG + ":"
+    + GraphQLApolloWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-ws")
 public class CustomGraphQLWsController {
 
-  private final GraphQLWsController controller;
+  private final GraphQLApolloWsController controller;
   private final GraphQLJsonSerializer serializer;
   private final SessionMetaData sessionMetaData;
 
-  public CustomGraphQLWsController(GraphQLWsController controller, GraphQLJsonSerializer serializer,
+  public CustomGraphQLWsController(GraphQLApolloWsController controller, GraphQLJsonSerializer serializer,
       SessionMetaData sessionMetaData) {
     this.controller = controller;
     this.serializer = serializer;
@@ -54,7 +54,7 @@ public class CustomGraphQLWsController {
   }
 
   @OnMessage
-  public Publisher<GraphQLWsResponse> onMessage(String message, WebSocketSession session) {
+  public Publisher<GraphQLApolloWsResponse> onMessage(String message, WebSocketSession session) {
     var type = serializer.deserialize(message, MessageType.class);
     var request = session.get("httpRequest", HttpRequest.class).get();
     if (ClientType.GQL_CONNECTION_INIT.getType().equals(type.type())) {
@@ -67,12 +67,12 @@ public class CustomGraphQLWsController {
   }
 
   @OnClose
-  public Publisher<GraphQLWsResponse> onClose(WebSocketSession session, CloseReason closeReason) {
+  public Publisher<GraphQLApolloWsResponse> onClose(WebSocketSession session, CloseReason closeReason) {
     return controller.onClose(session, closeReason);
   }
 
   @OnError
-  public Publisher<GraphQLWsResponse> onError(WebSocketSession session, Throwable t) {
+  public Publisher<GraphQLApolloWsResponse> onError(WebSocketSession session, Throwable t) {
     return controller.onError(session, t);
   }
 

--- a/backend/src/main/java/club/devcord/devmarkt/ws/ReflectiveUnsubscriber.java
+++ b/backend/src/main/java/club/devcord/devmarkt/ws/ReflectiveUnsubscriber.java
@@ -17,8 +17,8 @@
 package club.devcord.devmarkt.ws;
 
 import club.devcord.devmarkt.entities.auth.UserId;
-import io.micronaut.configuration.graphql.ws.GraphQLWsRequest;
-import io.micronaut.configuration.graphql.ws.GraphQLWsResponse;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsRequest;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse;
 import io.micronaut.context.BeanContext;
 import io.micronaut.websocket.WebSocketSession;
 import jakarta.inject.Singleton;
@@ -36,7 +36,7 @@ public class ReflectiveUnsubscriber{
   public ReflectiveUnsubscriber(BeanContext beanContext, SessionMetaData metaData) {
     this.metaData = metaData;
     try {
-      var stateClazz = Class.forName("io.micronaut.configuration.graphql.ws.GraphQLWsState");
+      var stateClazz = Class.forName("io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsState");
       this.wsState = beanContext.getBean(stateClazz);
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
@@ -53,13 +53,13 @@ public class ReflectiveUnsubscriber{
       var operationIdsField = activeOperations.getClass().getDeclaredField("activeOperations");
       operationIdsField.setAccessible(true);
       var operationIds = ((Map<String, ?>) operationIdsField.get(activeOperations)).keySet();
-      var method = wsState.getClass().getDeclaredMethod("stopOperation", GraphQLWsRequest.class,
+      var method = wsState.getClass().getDeclaredMethod("stopOperation", GraphQLApolloWsRequest.class,
           WebSocketSession.class);
       method.setAccessible(true);
       for (var id : operationIds) {
-        var request = new GraphQLWsRequest();
+        var request = new GraphQLApolloWsRequest();
         request.setId(id);
-        Flux.from((Publisher<GraphQLWsResponse>) method.invoke(wsState, request, session))
+        Flux.from((Publisher<GraphQLApolloWsResponse>) method.invoke(wsState, request, session))
             .subscribe(session::sendSync);
       }
     } catch (Throwable e) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-micronautVersion=3.9.4
+micronautVersion=4.0.0


### PR DESCRIPTION
1. Current WebSocket implementation was deprecated, that's the reason behind the package and classname change. https://micronaut-projects.github.io/micronaut-graphql/latest/guide/
2. Validation got extracted: https://micronaut-projects.github.io/micronaut-validation/latest/guide/index.html


Requires #217
