### PR TITLE
Update artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: docker save registry.gitlab.com/taucher2003-group/devmarkt-backend:${{ github.sha }} > qa-image.tar
       - name: Upload stored Images as artifact
         if: github.event_name != 'push' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: qa-image
           path: qa-image.tar
@@ -98,7 +98,7 @@ jobs:
           node-version: '16'
       - name: Download stored image as artifact
         if: github.event_name != 'push' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: qa-image
           path: qa-image.tar


### PR DESCRIPTION
The `v2` tag is deprecated and will result in a workflow failure in the future: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/